### PR TITLE
reduce block size/throughput by a factor of 2^N

### DIFF
--- a/src/sha256_transform.v
+++ b/src/sha256_transform.v
@@ -26,55 +26,87 @@
 // Perform a SHA-256 transformation on the given 512-bit data, and 256-bit
 // initial state,
 // Outputs one 256-bit hash every 1 cycle.
-module sha256_transform(clk, rx_state, rx_input, tx_hash);
-
-	parameter Ks = {32'h428a2f98, 32'h71374491, 32'hb5c0fbcf, 32'he9b5dba5, 32'h3956c25b, 32'h59f111f1, 32'h923f82a4, 32'hab1c5ed5, 32'hd807aa98, 32'h12835b01, 32'h243185be, 32'h550c7dc3, 32'h72be5d74, 32'h80deb1fe, 32'h9bdc06a7, 32'hc19bf174, 32'he49b69c1, 32'hefbe4786, 32'h0fc19dc6, 32'h240ca1cc, 32'h2de92c6f, 32'h4a7484aa, 32'h5cb0a9dc, 32'h76f988da, 32'h983e5152, 32'ha831c66d, 32'hb00327c8, 32'hbf597fc7, 32'hc6e00bf3, 32'hd5a79147, 32'h06ca6351, 32'h14292967, 32'h27b70a85, 32'h2e1b2138, 32'h4d2c6dfc, 32'h53380d13, 32'h650a7354, 32'h766a0abb, 32'h81c2c92e, 32'h92722c85, 32'ha2bfe8a1, 32'ha81a664b, 32'hc24b8b70, 32'hc76c51a3, 32'hd192e819, 32'hd6990624, 32'hf40e3585, 32'h106aa070, 32'h19a4c116, 32'h1e376c08, 32'h2748774c, 32'h34b0bcb5, 32'h391c0cb3, 32'h4ed8aa4a, 32'h5b9cca4f, 32'h682e6ff3, 32'h748f82ee, 32'h78a5636f, 32'h84c87814, 32'h8cc70208, 32'h90befffa, 32'ha4506ceb, 32'hbef9a3f7, 32'hc67178f2};
-
-	input clk;
-	input [255:0] rx_state;
-	input [511:0] rx_input;
-
-	output reg [255:0] tx_hash;
-
-
+module sha256_transform #(
+	parameter LOOP = 6'd4
+) (
+	input clk,
+	input feedback,
+	input [5:0]cnt,
+	input [255:0] rx_state,
+	input [511:0] rx_input,
+	output reg [255:0] tx_hash
+);
+	localparam Ks = {
+		32'h428a2f98, 32'h71374491, 32'hb5c0fbcf, 32'he9b5dba5,
+		32'h3956c25b, 32'h59f111f1, 32'h923f82a4, 32'hab1c5ed5,
+		32'hd807aa98, 32'h12835b01, 32'h243185be, 32'h550c7dc3,
+		32'h72be5d74, 32'h80deb1fe, 32'h9bdc06a7, 32'hc19bf174,
+		32'he49b69c1, 32'hefbe4786, 32'h0fc19dc6, 32'h240ca1cc,
+		32'h2de92c6f, 32'h4a7484aa, 32'h5cb0a9dc, 32'h76f988da,
+		32'h983e5152, 32'ha831c66d, 32'hb00327c8, 32'hbf597fc7,
+		32'hc6e00bf3, 32'hd5a79147, 32'h06ca6351, 32'h14292967,
+		32'h27b70a85, 32'h2e1b2138, 32'h4d2c6dfc, 32'h53380d13,
+		32'h650a7354, 32'h766a0abb, 32'h81c2c92e, 32'h92722c85,
+		32'ha2bfe8a1, 32'ha81a664b, 32'hc24b8b70, 32'hc76c51a3,
+		32'hd192e819, 32'hd6990624, 32'hf40e3585, 32'h106aa070,
+		32'h19a4c116, 32'h1e376c08, 32'h2748774c, 32'h34b0bcb5,
+		32'h391c0cb3, 32'h4ed8aa4a, 32'h5b9cca4f, 32'h682e6ff3,
+		32'h748f82ee, 32'h78a5636f, 32'h84c87814, 32'h8cc70208,
+		32'h90befffa, 32'ha4506ceb, 32'hbef9a3f7, 32'hc67178f2};
+	// How many time to loop on the same logic before advancing to next pipe stage
+	// At this point please keep this 2^N. We may fix this in the future to allow
+	// finer granularity in controlling design size
 
 	genvar i;
 
 	generate
 
-		for (i = 0; i < 64; i = i + 1) begin : HASHERS
+		for (i = 0; i < 64/LOOP; i = i + 1) begin : HASHERS
 			wire [511:0] W;
 			wire [255:0] state;
 
 			if(i == 0)
-				sha256_digester # (.K(32'h428a2f98)) U (clk, rx_input, rx_state, W, state);
+				sha256_digester U (
+					.clk(clk),
+					.k(feedback ? Ks[32*(64-LOOP*(i+1)-cnt) +: 32] : Ks[ `IDX(63) ]),
+					.rx_w(feedback ? W : rx_input),
+					.rx_state(feedback ? state : rx_state),
+					.tx_w(W),
+					.tx_state(state)
+				);
 			else
-				sha256_digester # (.K(Ks[ `IDX(63-i) ])) U (clk, HASHERS[i-1].W, HASHERS[i-1].state, W, state);
+				sha256_digester U (
+					.clk(clk),
+					.k(Ks[32*(64-LOOP*(i+1)-cnt) +: 32]),
+					.rx_w(feedback ? W : HASHERS[i-1].W),
+					.rx_state(feedback ? state : HASHERS[i-1].state),
+					.tx_w(W),
+					.tx_state(state)
+				);
 		end
 
 	endgenerate
 
 	always @ (posedge clk)
 	begin
-		tx_hash[`IDX(0)] <= rx_state[`IDX(0)] + HASHERS[63].state[`IDX(0)];
-		tx_hash[`IDX(1)] <= rx_state[`IDX(1)] + HASHERS[63].state[`IDX(1)];
-		tx_hash[`IDX(2)] <= rx_state[`IDX(2)] + HASHERS[63].state[`IDX(2)];
-		tx_hash[`IDX(3)] <= rx_state[`IDX(3)] + HASHERS[63].state[`IDX(3)];
-		tx_hash[`IDX(4)] <= rx_state[`IDX(4)] + HASHERS[63].state[`IDX(4)];
-		tx_hash[`IDX(5)] <= rx_state[`IDX(5)] + HASHERS[63].state[`IDX(5)];
-		tx_hash[`IDX(6)] <= rx_state[`IDX(6)] + HASHERS[63].state[`IDX(6)];
-		tx_hash[`IDX(7)] <= rx_state[`IDX(7)] + HASHERS[63].state[`IDX(7)];
+		tx_hash[`IDX(0)] <= rx_state[`IDX(0)] + HASHERS[64/LOOP-6'd1].state[`IDX(0)];
+		tx_hash[`IDX(1)] <= rx_state[`IDX(1)] + HASHERS[64/LOOP-6'd1].state[`IDX(1)];
+		tx_hash[`IDX(2)] <= rx_state[`IDX(2)] + HASHERS[64/LOOP-6'd1].state[`IDX(2)];
+		tx_hash[`IDX(3)] <= rx_state[`IDX(3)] + HASHERS[64/LOOP-6'd1].state[`IDX(3)];
+		tx_hash[`IDX(4)] <= rx_state[`IDX(4)] + HASHERS[64/LOOP-6'd1].state[`IDX(4)];
+		tx_hash[`IDX(5)] <= rx_state[`IDX(5)] + HASHERS[64/LOOP-6'd1].state[`IDX(5)];
+		tx_hash[`IDX(6)] <= rx_state[`IDX(6)] + HASHERS[64/LOOP-6'd1].state[`IDX(6)];
+		tx_hash[`IDX(7)] <= rx_state[`IDX(7)] + HASHERS[64/LOOP-6'd1].state[`IDX(7)];
 	end
 
 
 endmodule
 
 
-module sha256_digester (clk, rx_w, rx_state, tx_w, tx_state);
-
-	parameter K = 32'h00000000;
+module sha256_digester (clk, k, rx_w, rx_state, tx_w, tx_state);
 
 	input clk;
+	input  [31:0] k;
 	input [511:0] rx_w;
 	input [255:0] rx_state;
 
@@ -92,7 +124,7 @@ module sha256_digester (clk, rx_w, rx_state, tx_w, tx_state);
 	s0	s0_blk	(rx_w[63:32], s0_w);
 	s1	s1_blk	(rx_w[479:448], s1_w);
 
-	wire [31:0] t1 = rx_state[`IDX(7)] + e1_w + ch_w + rx_w[31:0] + K;
+	wire [31:0] t1 = rx_state[`IDX(7)] + e1_w + ch_w + rx_w[31:0] + k;
 	wire [31:0] t2 = e0_w + maj_w;
 	wire [31:0] new_w = s1_w + rx_w[319:288] + s0_w + rx_w[31:0];
 	

--- a/src/sha256_transform.v
+++ b/src/sha256_transform.v
@@ -68,7 +68,7 @@ module sha256_transform #(
 			if(i == 0)
 				sha256_digester U (
 					.clk(clk),
-					.k(feedback ? Ks[32*(64-LOOP*(i+1)-cnt) +: 32] : Ks[ `IDX(63) ]),
+					.k(feedback ? Ks[32*(63-cnt) +: 32] : Ks[ `IDX(63) ]),
 					.rx_w(feedback ? W : rx_input),
 					.rx_state(feedback ? state : rx_state),
 					.tx_w(W),
@@ -77,7 +77,7 @@ module sha256_transform #(
 			else
 				sha256_digester U (
 					.clk(clk),
-					.k(Ks[32*(64-LOOP*(i+1)-cnt) +: 32]),
+					.k(Ks[32*(63-LOOP*i-cnt) +: 32]),
 					.rx_w(feedback ? W : HASHERS[i-1].W),
 					.rx_state(feedback ? state : HASHERS[i-1].state),
 					.tx_w(W),


### PR DESCRIPTION
This change introduces a LOOP_LOG2 parameter that can reduce the design's
throughput and size by a factor of 2^N.
A factor of 8 enables it to fit in an EP3C25 (>90% utilization).
LOOP_LOG2=0 should be identical to your original code.
Design not fully verified yet. Please test before committing!
