### PR TITLE
Improve code for K lookup to increase achievable clock speed.

### DIFF
--- a/projects/LX150_makomk_Test/hdl/sha256_transform.v
+++ b/projects/LX150_makomk_Test/hdl/sha256_transform.v
@@ -201,7 +201,7 @@ module sha256_transform #(
 					.clk(clk),
 					.k_next(K_next),
 					.rx_state(feedback ? state_fb : rx_state),
-					.rx_t1_part(feedback ? t1_part_fb : (rx_state[`IDX(7)] + cur_w0 + K)),
+					.rx_t1_part(feedback ? t1_part_fb : (rx_state[`IDX(7)] + rx_input[31:0] + K)),
 					.rx_w1(cur_w1),
 					.tx_state(state),
 					.tx_t1_part(t1_part_next)


### PR DESCRIPTION
Hi. This patch improves the way the values of K and K_next are looked up, hopefully allowing faster clock speeds. (I'm seeing successful synthesis at 100MHz with LOOP_LOG2=1 on XC6SLX75 and am hoping for a similar improvement for the fully unrolled design on XC6SLX150). Obviously I can't test this on a real FPGA or synthesize the design for XC6SLX150 though.

I'd be grateful if you could check this works for LOOP_LOG2=0 and 1, and if so merge it.

Aidan.
